### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/andrmaz/wallet/security/code-scanning/1](https://github.com/andrmaz/wallet/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` block with the minimal privileges required. Since none of the listed job steps in the workflow require write access to the repository (no pushes, no PR/issue creation or updates, etc.), the minimal permission of `contents: read` is sufficient. This block should be added at the top workflow level (just after the `name` field and before `on`), so it covers the entire workflow unless a job needs a special override.

Specifically, insert the following lines:

```yaml
permissions:
  contents: read
```

right after the `name: CI` line, i.e., between lines 1 and 2.

No new imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
